### PR TITLE
Forbidden characters aren't removed from the filename

### DIFF
--- a/CurlAxel.php
+++ b/CurlAxel.php
@@ -295,7 +295,7 @@ class CurlAxel {
 		if (is_string($filename)) {
 			/* remove forbidden characters from filename */
 			$forbidden = '<>:"/\\|?*\'@#+~{}[]^';
-			str_replace($forbidden, '', $filename);
+			str_replace(str_split($forbidden), '', $filename);
 			$this->filename = $filename;
 			return true;
 		}


### PR DESCRIPTION
str_replace is searching the full string of the forbidden characters.
Using str_split in the string will fix that.
